### PR TITLE
Alter receiver name for consistency

### DIFF
--- a/singleflight.go
+++ b/singleflight.go
@@ -76,6 +76,6 @@ func (caller *Caller[K, V]) Call(ctx context.Context, key K, fn func(context.Con
 type contextKeyType[K comparable] struct{}
 
 // KeyFromContext returns the key ctx carries. It panics in case ctx carries no key.
-func (c *Caller[K, V]) KeyFromContext(ctx context.Context) K {
+func (caller *Caller[K, V]) KeyFromContext(ctx context.Context) K {
 	return ctx.Value(contextKeyType[K]{}).(K)
 }


### PR DESCRIPTION
This PR alters the receiver name of `KeyFromContext` for consistency.