### PR TITLE
Bump minimum required Go version to 1.23.0 & x/sync to v0.14.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/azazeal/singleflight
 
-go 1.18
+go 1.23.0
 
-require golang.org/x/sync v0.11.0
+require golang.org/x/sync v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=
-golang.org/x/sync v0.11.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sync v0.14.0 h1:woo0S4Yywslg6hp4eUFjTVOyKt0RookbpAHG4c1HmhQ=
+golang.org/x/sync v0.14.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=


### PR DESCRIPTION
This PR bumps the minimum required Go version to `1.23.0` and `golang.org/x/sync` to v0.14.0.