### PR TITLE
Bump minimum required Go version to 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/azazeal/singleflight
 
-go 1.23.0
+go 1.24.0
 
-require golang.org/x/sync v0.16.0
+require golang.org/x/sync v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sync v0.16.0 h1:ycBJEhp9p4vXvUZNszeOq0kGTPghopOL8q0fq3vstxw=
-golang.org/x/sync v0.16.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
+golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=

--- a/singleflight_test.go
+++ b/singleflight_test.go
@@ -41,7 +41,7 @@ func Test(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			*r, *err = caller.Call(context.Background(), key, fn)
+			*r, *err = caller.Call(t.Context(), key, fn)
 		}()
 	}
 
@@ -65,7 +65,7 @@ func Test(t *testing.T) {
 	assertEqual(t, executions, 1)
 
 	// ensure further executions once concurrent callers finish
-	r3, err3 := caller.Call(context.Background(), key+"1", fn)
+	r3, err3 := caller.Call(t.Context(), key+"1", fn)
 
 	assertFalse(t, r3)
 	assertError(t, err3)
@@ -93,7 +93,7 @@ func TestSecondaryContextCancellation(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		got1, err1 = caller.Call(context.Background(), key, fn)
+		got1, err1 = caller.Call(t.Context(), key, fn)
 	}()
 
 	wg.Add(1)
@@ -102,7 +102,7 @@ func TestSecondaryContextCancellation(t *testing.T) {
 
 		time.Sleep(shortPause)
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		go func() {
 			time.Sleep(shortPause)
 			cancel()
@@ -117,7 +117,7 @@ func TestSecondaryContextCancellation(t *testing.T) {
 
 		time.Sleep(shortPause)
 
-		ctx, cancel := context.WithTimeout(context.Background(), mediumPause)
+		ctx, cancel := context.WithTimeout(t.Context(), mediumPause)
 		defer cancel()
 
 		got3, err3 = caller.Call(ctx, key, fn)


### PR DESCRIPTION
This PR bumps the minimum required Go version to 1.24.

It also bumps the `golang.org/x/sync` dependency to `v0.17.0`.